### PR TITLE
Make VPC deployment optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,32 @@
 IMPROVEMENTS:
 
 * The zone ID and the DNS name of the ELB are now output from the module.   
+
+## 0.1.5 (November 27 2020)
+
+IMPROVEMENTS:
+
+* Added a new boolean `deploy_in_vpc` flag to disable VPC deployments.
+
+   This enables the lambda to be used more easily when you want to access
+   global AWS Services without having to configure a VPC or routing. 
+   To avoid breaking changes, the default mode is to deploy inside a VPC environment.
+   
+   When `deploy_in_vpc` is set to false, the `sg_lambda` security_group is not created 
+   and the `vpc_config` is passed empty values to create an AWS Lambda outside of a VPC.
+
+* Added `tags` input to tag terraform managed resources
+   
+   A map of AWS tags can now be passed in via the `tags` input variable. The default tags are:
+   ```json
+    {
+     "Name": "aws-terraform-lambda",
+     "terraform": true
+    } 
+  ```
+* Removed the hard-coded AWS Region and AWS Account Id's in `lambda_execution_policy`.
+* Added `include_route53_zone_association = false` to test prerequisites to simplify test harness deployment 
+* Added ` "ec2:AssignPrivateIpAddresses", "ec2:UnassignPrivateIpAddresses"` to default execution policy
+to bring it inline with Amazon's default AWSLambdaVPCAccessExecutionRole.
+* Added an optional `lambda_description` variable
+* Added descriptions to variables for improved IDE code hints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
-* Added a new boolean `deploy_in_vpc` flag to disable VPC deployments.
+* Added a new `deploy_in_vpc` flag to disable VPC deployments.
 
    This enables the lambda to be used more easily when you want to access
    global AWS Services without having to configure a VPC or routing. 
    To avoid breaking changes, the default mode is to deploy inside a VPC environment.
    
-   When `deploy_in_vpc` is set to false, the `sg_lambda` security_group is not created 
+   When `deploy_in_vpc` is set to "no", the `sg_lambda` security_group is not created 
    and the `vpc_config` is passed empty values to create an AWS Lambda outside of a VPC.
 
 * Added `tags` input to tag terraform managed resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,18 @@ IMPROVEMENTS:
 * Added `tags` input to tag terraform managed resources
    
    A map of AWS tags can now be passed in via the `tags` input variable. The default tags are:
-   ```json
-    {
-     "Name": "aws-terraform-lambda",
-     "terraform": true
-    } 
-  ```
+    ```json
+     {
+         "Component" = "<component>",
+         "DeploymentType" = "<deployment_type>",
+         "DeploymentLabel" = "<deployment_label>",
+         "DeploymentIdentifier" = "<deployment_identifier>"
+       } 
+    ```
 * Removed the hard-coded AWS Region and AWS Account Id's in `lambda_execution_policy`.
 * Added `include_route53_zone_association = false` to test prerequisites to simplify test harness deployment 
 * Added ` "ec2:AssignPrivateIpAddresses", "ec2:UnassignPrivateIpAddresses"` to default execution policy
 to bring it inline with Amazon's default AWSLambdaVPCAccessExecutionRole.
 * Added an optional `lambda_description` variable
 * Added descriptions to variables for improved IDE code hints
+* Added `deployment_type` and `deployment_label` variables for tagging resources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ module "lambda" {
   source  = "infrablocks/lambda/aws"
   region                = "eu-west-2"
   component             = "my-lambda"
-  deployment_identifier = "production"
+  deployment_identifier = "development-europe"
+  deployment_label = "europe"
+  deployment_type = "development"
   deploy_in_vpc = true
   account_id = "11122233355"
   vpc_id = "VPC-1234"
@@ -39,8 +41,10 @@ module "lambda" {
   lambda_handler = "handler.hello"
   lambda_description = "An optional description"
   tags =  {
-             Name = "my-lambda-name",
-             Terraform = true
+            Component = "my-lambda",
+            DeploymentType = "development",
+            DeploymentLabel = "europe",
+            DeploymentIdentifier = "development-europe"
            }
   lambda_execution_policy =  jsonencode(
       {
@@ -83,6 +87,8 @@ module "lambda" {
 | region                           | AWS Region                         | -                   | yes                                  |
 | component| The component for which the load balancer is being created    |- | yes|
 | deployment_identifier|An identifier for this instantiation                                           |- | yes |
+| deployment_label | A unique label per deployment | - | yes |
+| deployment_type | The type of deployment, e.g. development, production | - | | yes|
 | account_id|AWS account ID                                           |- | yes |
 | vpc_id|VPC to deploy lambda to                                           |- | yes |
 | deploy_in_vpc | A boolean flag to disable VPC deployment | true | no
@@ -94,8 +100,8 @@ module "lambda" {
 | lambda_function_name| lambda function name |- | yes |
 | lambda_handler| handler path for lambda |- | yes |
 | lambda_environment_variables| environment variables for lambda|- | yes |
-| lambda_execution_policy | An inline policy to use for the lambda | - | no
-| lambda_description | A description to use for the lambda | - | no
+| lambda_execution_policy | An inline policy to use for the lambda | - | no |
+| lambda_description | A description to use for the lambda | - | no| 
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module "lambda" {
   deployment_identifier = "development-europe"
   deployment_label = "europe"
   deployment_type = "development"
-  deploy_in_vpc = true
+  deploy_in_vpc = "yes"
   account_id = "11122233355"
   vpc_id = "VPC-1234"
   lambda_subnet_ids = "subnet-id-1"
@@ -41,10 +41,7 @@ module "lambda" {
   lambda_handler = "handler.hello"
   lambda_description = "An optional description"
   tags =  {
-            Component = "my-lambda",
-            DeploymentType = "development",
-            DeploymentLabel = "europe",
-            DeploymentIdentifier = "development-europe"
+            "AdditionalTags" = "my-tag"
            }
   lambda_execution_policy =  jsonencode(
       {
@@ -91,7 +88,7 @@ module "lambda" {
 | deployment_type | The type of deployment, e.g. development, production | - | | yes|
 | account_id|AWS account ID                                           |- | yes |
 | vpc_id|VPC to deploy lambda to                                           |- | yes |
-| deploy_in_vpc | A boolean flag to disable VPC deployment | true | no
+| deploy_in_vpc | A flag to disable VPC deployment | yes | no
 | tags | The AWS tags to use for any deployed resources | - | no 
 | lambda_subnet_ids| subnet ids for the lambda |- | yes |
 | lambda_zip_path| location of your lambda zip archive |- | yes |
@@ -122,11 +119,11 @@ module "lambda" {
 
 ### Private VPC Deployment 
 
-The module deploys the lambda into the configured VPC by default. If `deploy_in_vpc` is set to false - 
+The module deploys the lambda into the configured VPC by default. If `deploy_in_vpc` is set to "no" then
 the AWS lambda will be deployed outside of a private VPC environment.
 
-Remember that when deploying the lambda inside a VPC environment you will need to configure the appropriate routing and security 
-group permissions if you require access to AWS Services.
+Remember that when deploying the lambda inside a VPC environment you will need to configure the appropriate routing
+and security group permissions if you require access to AWS Services.
 
 ### Execution IAM Policy
 
@@ -136,6 +133,11 @@ If you want to customise the execution policy for the lambda then you can option
 Be sure to include the permissions listed in the default policy so that the lambda
 can be created successfully, see `lambda_execution_policy` for the default policy.
 
+### Tags
+
+The module deploys `Component`, `DeploymentType`, `DeploymentLabel` and `DeploymentIdentifier` tags 
+for any created infrastructure by default. Additional tags can be optionally passed in via the `tags` input variable,
+which will then be merged together with the default tags.
 
 Development
 -----------

--- a/TODO.md
+++ b/TODO.md
@@ -6,4 +6,6 @@ TODO
   - Could provision for a different module definition each time
 * Use hiera config
   - Can't currently use listener configuration from external configuration
-* Add tags to security groups
+*  ~~Add tags to security groups~~
+
+* Add test for non-vpc mode deployment

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1,4 +1,5 @@
 ---
+account_id: "579878096224"
 region: 'eu-west-2'
 
 component: 'test'
@@ -6,20 +7,19 @@ component: 'test'
 work_directory: 'build'
 configuration_directory: "%{hiera('work_directory')}/%{hiera('source_directory')}"
 
+deploy_in_vpc: "yes"
 private_zone_id: 'Z2CDAFD23Q10HO'
-
 vpc_cidr: "10.1.0.0/16"
 availability_zones:
   - "eu-west-2a"
   - "eu-west-2b"
 
-account_id: "579878096224"
-
-lambda_zip_path: 'lambda.zip'
 lambda_ingress_cidr_blocks:
   - "10.0.0.0/8"
 lambda_egress_cidr_blocks:
   - "0.0.0.0/0"
+
+lambda_zip_path: 'lambda.zip'
 lambda_environment_variables: '{"TEST_ENV_VARIABLE"="test-value"}'
 lambda_function_name: "test-lambda-resource"
 lambda_description: "test terraform-aws-lambda"

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -22,5 +22,5 @@ lambda_egress_cidr_blocks:
   - "0.0.0.0/0"
 lambda_environment_variables: '{"TEST_ENV_VARIABLE"="test-value"}'
 lambda_function_name: "test-lambda-resource"
+lambda_description: "test terraform-aws-lambda"
 lambda_handler: "handler.hello"
-tags: {"Name": "terraform-aws-lambda", "terraform": "true"}

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -23,3 +23,4 @@ lambda_egress_cidr_blocks:
 lambda_environment_variables: '{"TEST_ENV_VARIABLE"="test-value"}'
 lambda_function_name: "test-lambda-resource"
 lambda_handler: "handler.hello"
+tags: {"Name": "terraform-aws-lambda", "terraform": "true"}

--- a/config/roles/harness.yaml
+++ b/config/roles/harness.yaml
@@ -6,11 +6,18 @@ vars:
 
   component: "%{hiera('component')}"
   deployment_identifier: "%{hiera('deployment_identifier')}"
+  deployment_label: "%{hiera('deployment_label')}"
+  deployment_type: "%{hiera('deployment_type')}"
+  deploy_in_vpc: "%{hiera('deploy_in_vpc')}"
+
   account_id: "%{hiera('account_id')}"
+  tags: "%{hiera('tags')}"
+
 
   lambda_zip_path: "%{hiera('lambda_zip_path')}"
   lambda_ingress_cidr_blocks: "%{hiera('lambda_ingress_cidr_blocks')}"
   lambda_egress_cidr_blocks: "%{hiera('lambda_egress_cidr_blocks')}"
   lambda_environment_variables: "%{hiera('lambda_environment_variables')}"
   lambda_function_name: "%{hiera('lambda_function_name')}"
+  lambda_description: "%{hiera('lambda_description')}"
   lambda_handler: "%{hiera('lambda_handler')}"

--- a/config/roles/prerequisites.yaml
+++ b/config/roles/prerequisites.yaml
@@ -7,7 +7,6 @@ vars:
 
   component: "%{hiera('component')}"
   deployment_identifier: "%{hiera('deployment_identifier')}"
-
   private_zone_id: "%{hiera('private_zone_id')}"
 
   vpc_cidr: "%{hiera('vpc_cidr')}"

--- a/iam.tf
+++ b/iam.tf
@@ -3,11 +3,43 @@ data "aws_caller_identity" "current" {
 
 resource "aws_iam_role" "lambda_execution_role" {
   assume_role_policy = var.lambda_assume_role
-
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy" "lambda_execution_policy" {
   role = aws_iam_role.lambda_execution_role.id
-  policy = var.lambda_execution_policy
+  policy = var.lambda_execution_policy != "" ? var.lambda_execution_policy : jsonencode(
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs"
+        ],
+        "Resource": [
+          "*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        "Resource": [
+          "arn:aws:logs:${var.region}:${var.account_id}:*"
+        ]
+      }
+    ]
+  })
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {
 
 resource "aws_iam_role" "lambda_execution_role" {
   assume_role_policy = var.lambda_assume_role
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy" "lambda_execution_policy" {

--- a/lambda.tf
+++ b/lambda.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "lambda" {
   runtime = var.lambda_runtime
   timeout = var.lambda_timeout
   memory_size = var.lambda_memory_size
-  tags = var.tags
+  tags = local.tags
 
   environment {
     variables = var.lambda_environment_variables

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,4 +1,5 @@
 resource "aws_lambda_function" "lambda" {
+  description = var.lambda_description
   filename = var.lambda_zip_path
   function_name = var.lambda_function_name
   role = aws_iam_role.lambda_execution_role.arn
@@ -7,15 +8,17 @@ resource "aws_lambda_function" "lambda" {
   runtime = var.lambda_runtime
   timeout = var.lambda_timeout
   memory_size = var.lambda_memory_size
+  tags = var.tags
+
   environment {
     variables = var.lambda_environment_variables
   }
 
   vpc_config {
-    security_group_ids = [
-      aws_security_group.sg_lambda.id
-    ]
-    subnet_ids = var.lambda_subnet_ids
+    security_group_ids = var.deploy_in_vpc ? [
+      aws_security_group.sg_lambda[0].id
+    ] : []
+    subnet_ids = var.deploy_in_vpc ? var.lambda_subnet_ids : []
   }
 
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -15,10 +15,10 @@ resource "aws_lambda_function" "lambda" {
   }
 
   vpc_config {
-    security_group_ids = var.deploy_in_vpc ? [
+    security_group_ids = var.deploy_in_vpc == "yes" ? [
       aws_security_group.sg_lambda[0].id
     ] : []
-    subnet_ids = var.deploy_in_vpc ? var.lambda_subnet_ids : []
+    subnet_ids = var.deploy_in_vpc == "yes" ? var.lambda_subnet_ids : []
   }
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  base_tags = {
+    "Component" = var.component,
+    "DeploymentType" = var.deployment_type,
+    "DeploymentLabel" = var.deployment_label,
+    "DeploymentIdentifier" = var.deployment_identifier
+  }
+
+  tags = merge(var.tags, local.base_tags)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,7 @@ output "lambda_version" {
 }
 
 output "security_group_name" {
-  value = aws_security_group.sg_lambda.name
+  value = var.deploy_in_vpc ? aws_security_group.sg_lambda[0].name : ""
 }
 
 output "iam_role_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,15 +31,12 @@ output "lambda_source_code_size" {
 output "lambda_version" {
   value = aws_lambda_function.lambda.version
 }
-
 output "security_group_name" {
-  value = var.deploy_in_vpc ? aws_security_group.sg_lambda[0].name : ""
+  value = var.deploy_in_vpc == "yes" ? aws_security_group.sg_lambda[0].name : ""
 }
-
 output "iam_role_name" {
   value = aws_iam_role.lambda_execution_role.name
 }
-
 output "iam_role_policy_name" {
   value =  aws_iam_role_policy.lambda_execution_policy.name
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "sg_lambda" {
   description = "${var.deployment_identifier}-lambda"
   vpc_id = var.vpc_id
-  tags = var.tags
+  tags = local.tags
   count = var.deploy_in_vpc ? 1 : 0
 
   ingress {

--- a/security_group.tf
+++ b/security_group.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "sg_lambda" {
   description = "${var.deployment_identifier}-lambda"
   vpc_id = var.vpc_id
   tags = local.tags
-  count = var.deploy_in_vpc ? 1 : 0
+  count = var.deploy_in_vpc == "yes" ? 1 : 0
 
   ingress {
     from_port = 0

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,6 +1,8 @@
 resource "aws_security_group" "sg_lambda" {
   description = "${var.deployment_identifier}-lambda"
   vpc_id = var.vpc_id
+  tags = var.tags
+  count = var.deploy_in_vpc ? 1 : 0
 
   ingress {
     from_port = 0

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -12,6 +12,8 @@ module "lambda" {
   region = var.region
   component = var.component
   deployment_identifier = var.deployment_identifier
+  deployment_type = var.deployment_type
+  deployment_label = var.deployment_label
 
   account_id = var.account_id
   vpc_id = data.terraform_remote_state.prerequisites.outputs.vpc_id
@@ -23,4 +25,5 @@ module "lambda" {
   lambda_environment_variables = var.lambda_environment_variables
   lambda_function_name = var.lambda_function_name
   lambda_handler = var.lambda_handler
+
 }

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -17,7 +17,7 @@ module "lambda" {
 
   account_id = var.account_id
   vpc_id = data.terraform_remote_state.prerequisites.outputs.vpc_id
-  deploy_in_vpc = true
+  deploy_in_vpc = var.deploy_in_vpc
   lambda_subnet_ids = data.terraform_remote_state.prerequisites.outputs.private_subnet_ids
   lambda_zip_path = var.lambda_zip_path
   lambda_ingress_cidr_blocks = var.lambda_ingress_cidr_blocks
@@ -25,5 +25,4 @@ module "lambda" {
   lambda_environment_variables = var.lambda_environment_variables
   lambda_function_name = var.lambda_function_name
   lambda_handler = var.lambda_handler
-
 }

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -15,7 +15,7 @@ module "lambda" {
 
   account_id = var.account_id
   vpc_id = data.terraform_remote_state.prerequisites.outputs.vpc_id
-
+  deploy_in_vpc = true
   lambda_subnet_ids = data.terraform_remote_state.prerequisites.outputs.private_subnet_ids
   lambda_zip_path = var.lambda_zip_path
   lambda_ingress_cidr_blocks = var.lambda_ingress_cidr_blocks

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -1,6 +1,8 @@
 variable "region" {}
 variable "component" {}
 variable "deployment_identifier" {}
+variable "deployment_label" {}
+variable "deployment_type" {}
 
 variable "account_id" {}
 
@@ -16,3 +18,6 @@ variable "lambda_environment_variables" {
 }
 variable "lambda_function_name" {}
 variable "lambda_handler" {}
+variable "lambda_description" {}
+variable "deploy_in_vpc" {}
+variable "tags" {}

--- a/spec/infra/prerequisites/main.tf
+++ b/spec/infra/prerequisites/main.tf
@@ -8,6 +8,6 @@ module "base_network" {
 
   component = var.component
   deployment_identifier = var.deployment_identifier
-
+  include_route53_zone_association = false
   private_zone_id = var.private_zone_id
 }

--- a/spec/infra/prerequisites/variables.tf
+++ b/spec/infra/prerequisites/variables.tf
@@ -8,10 +8,3 @@ variable "availability_zones" {
 }
 variable "private_zone_id" {}
 
-variable "tags" {
-  description = "AWS tags to use on created infrastructure components"
-  type = map(string)
-  default = {
-    "Name" = "terraform-aws-lambda-test-prerequisites"
-  }
-}

--- a/spec/infra/prerequisites/variables.tf
+++ b/spec/infra/prerequisites/variables.tf
@@ -7,3 +7,11 @@ variable "availability_zones" {
   type = list(string)
 }
 variable "private_zone_id" {}
+
+variable "tags" {
+  description = "AWS tags to use on created infrastructure components"
+  type = map(string)
+  default = {
+    "Name" = "terraform-aws-lambda-test-prerequisites"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,14 @@ variable "deployment_identifier" {
   description = "The deployment identifier to use e.g. <deployment_type>-<deployment_label>"
 }
 
+variable "deployment_label" {
+  description = "The deployment label to use"
+}
+
+variable "deployment_type" {
+  description = "The deployment type to use"
+}
+
 # Lambda Settings
 
 variable "lambda_function_name" {
@@ -78,10 +86,18 @@ variable "lambda_environment_variables" {
   type = map(string)
 }
 
+locals {
+  tags = var.tags != null ? var.tags  : {
+    "Component" = var.component,
+    "DeploymentType" = var.deployment_type,
+    "DeploymentLabel" = var.deployment_label,
+    "DeploymentIdentifier" = var.deployment_identifier
+  }
+}
+
 variable "tags" {
   description = "AWS tags to use on created infrastructure components"
-  type = map(string)
-  default = { "Name" = "terraform-aws-lambda", "terraform" = true }
+  default = null
 }
 
 # Deployment Options

--- a/variables.tf
+++ b/variables.tf
@@ -1,49 +1,60 @@
 # Component / Service & AWS Account Settings
 variable "region" {
-  description = "AWS region"
+  description = "The region into which to deploy the Lambda."
+  type        = string
 }
 
 variable "account_id" {
   description = "AWS account id where the lambda execution"
+  type        = string
 }
 
 variable "component" {
   description = "The name of the component or service"
+  type        = string
 }
 
 variable "deployment_identifier" {
-  description = "The deployment identifier to use e.g. <deployment_type>-<deployment_label>"
+  description = "An identifier for this instantiation e.g. <deployment_type>-<deployment_label>"
+  type        = string
 }
 
 variable "deployment_label" {
   description = "The deployment label to use"
+  type        = string
 }
 
 variable "deployment_type" {
   description = "The deployment type to use"
+  type        = string
 }
 
 # Lambda Settings
 
 variable "lambda_function_name" {
   description = "The name to use for the lambda function"
+  type        = string
 }
 
 variable "lambda_description" {
   description = "The description to use for the AWS Lambda"
+  type        = string
   default = ""
 }
 
 variable "lambda_handler" {
   description = "The name of the handler to use for the lambda function"
+  type        = string
 }
 
 variable "lambda_zip_path" {
   description = "The location where the generated zip file should be stored"
+  type        = string
 }
 
 variable "lambda_runtime" {
   description = "The runtime to use for the lambda function"
+  type        = string
   default = "nodejs10.x"
 }
 
@@ -59,6 +70,7 @@ variable "lambda_memory_size" {
 
 variable "lambda_execution_policy" {
   description = "The inline AWS execution policy to use for the lambda"
+  type        = string
   default =  ""
 }
 
@@ -86,43 +98,39 @@ variable "lambda_environment_variables" {
   type = map(string)
 }
 
-locals {
-  tags = var.tags != null ? var.tags  : {
-    "Component" = var.component,
-    "DeploymentType" = var.deployment_type,
-    "DeploymentLabel" = var.deployment_label,
-    "DeploymentIdentifier" = var.deployment_identifier
-  }
-}
-
 variable "tags" {
   description = "AWS tags to use on created infrastructure components"
-  default = null
+  type = map(string)
+  default = {}
 }
+
 
 # Deployment Options
 
 variable "deploy_in_vpc" {
-  description = "Set to true to deploy the lambda in a vpc environment"
-  type = bool
-  default = true
+  description = "Whether or not to deploy the lambda into a VPC (\"yes\" or \"no\")."
+  type = string
+  default = "yes"
 }
 
 # VPC Deployment Settings
 
 variable "vpc_id" {
-  description = "VPC to deploy the lambda to"
+  description = "The ID of the VPC into which to deploy the lambda."
+  type        = string
 }
 
 variable "lambda_subnet_ids" {
-  description = "Subnet ids to deploy the lambda to"
+  description = "The IDs of the subnets for the lambda"
   type = list(string)
 }
 
 variable "lambda_ingress_cidr_blocks" {
+  description = "The ingress CIDR ranges to allow access"
   type = list(string)
 }
 
 variable "lambda_egress_cidr_blocks" {
+  description = "The egress CIDR ranges to allow access"
   type = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,96 +1,62 @@
+# Component / Service & AWS Account Settings
 variable "region" {
   description = "AWS region"
 }
-
-variable "component" {}
-variable "deployment_identifier" {}
 
 variable "account_id" {
   description = "AWS account id where the lambda execution"
 }
 
-variable "vpc_id" {
-  description = "VPC to deploy the lambda to"
+variable "component" {
+  description = "The name of the component or service"
 }
 
-variable "lambda_subnet_ids" {
-  description = "Subnet ids to deploy the lambda to"
-  type = list(string)
+variable "deployment_identifier" {
+  description = "The deployment identifier to use e.g. <deployment_type>-<deployment_label>"
 }
 
+# Lambda Settings
 
-variable "lambda_zip_path" {}
-
-variable "lambda_ingress_cidr_blocks" {
-  type = list(string)
+variable "lambda_function_name" {
+  description = "The name to use for the lambda function"
 }
 
-variable "lambda_egress_cidr_blocks" {
-  type = list(string)
+variable "lambda_description" {
+  description = "The description to use for the AWS Lambda"
+  default = ""
 }
 
-variable "lambda_environment_variables" {
-  description = "Environment variables to be provied to the lambda function."
-  type = map(string)
+variable "lambda_handler" {
+  description = "The name of the handler to use for the lambda function"
 }
 
-variable "lambda_function_name" {}
-
-variable "lambda_handler" {}
+variable "lambda_zip_path" {
+  description = "The location where the generated zip file should be stored"
+}
 
 variable "lambda_runtime" {
+  description = "The runtime to use for the lambda function"
   default = "nodejs10.x"
 }
 
 variable "lambda_timeout" {
+  description = "The timeout period to use for the lambda function"
   default = 30
 }
 
 variable "lambda_memory_size" {
+  description = "The amount of memeory to use for the lambda function"
   default = 128
 }
 
 variable "lambda_execution_policy" {
-  default =  <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:CreateNetworkInterface",
-        "ec2:DeleteNetworkInterface",
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs"
-      ],
-      "Resource": [
-        "*"
-      ]
-    },
-    {
-            "Effect": "Allow",
-            "Action": "logs:CreateLogGroup",
-            "Resource": "arn:aws:logs:eu-west-1:*:*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-            ],
-            "Resource": [
-                "arn:aws:logs:eu-west-1:702464176885:*"
-            ]
-        }
-  ]
-}
-EOF
+  description = "The inline AWS execution policy to use for the lambda"
+  default =  ""
 }
 
 variable "lambda_assume_role" {
- default = <<EOF
+  description = "An inline AWS role policy which the lambda should assume during execution"
+  default = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -107,3 +73,40 @@ EOF
 
 }
 
+variable "lambda_environment_variables" {
+  description = "Environment variables to be provied to the lambda function."
+  type = map(string)
+}
+
+variable "tags" {
+  description = "AWS tags to use on created infrastructure components"
+  type = map(string)
+  default = { "Name" = "terraform-aws-lambda", "terraform" = true }
+}
+
+# Deployment Options
+
+variable "deploy_in_vpc" {
+  description = "Set to true to deploy the lambda in a vpc environment"
+  type = bool
+  default = true
+}
+
+# VPC Deployment Settings
+
+variable "vpc_id" {
+  description = "VPC to deploy the lambda to"
+}
+
+variable "lambda_subnet_ids" {
+  description = "Subnet ids to deploy the lambda to"
+  type = list(string)
+}
+
+variable "lambda_ingress_cidr_blocks" {
+  type = list(string)
+}
+
+variable "lambda_egress_cidr_blocks" {
+  type = list(string)
+}


### PR DESCRIPTION
Hi Toby,

I've made some changes to enable the lambda to deployed outside of a private VPC environment. I hope the changes look reasonable, but please feel free to comment if you want me to go back and revisit any parts of the code or explain anything. 

I'm afraid I haven't added any tests around the non-vpc deployment as I couldn't quite wrap my head around ruby spec and need to go away and learn more Ruby first. 

Any feedback would be welcome!

Cheers,

Chris

### Summary of Changes:

* Added a new `deploy_in_vpc` flag to disable VPC deployments.

   This enables the lambda to be used more easily when you want to access
   global AWS Services without having to configure a VPC or routing. 
   To avoid breaking changes, the default mode is to deploy inside a VPC environment.
   
   When `deploy_in_vpc` is set to false, the `sg_lambda` security_group is not created 
   and the `vpc_config` is passed empty values to create an AWS Lambda outside of a VPC.

* Added `tags` input to tag terraform managed resources
   
   A map of AWS tags can now be passed in via the `tags` input variable. The default tags are:
   ```json
    {
     "Name": "aws-terraform-lambda",
     "terraform": true
    } 
  ```
* Removed the hard-coded AWS Region and AWS Account Id's in `lambda_execution_policy`.
* Added `include_route53_zone_association = false` to test prerequisites to simplify test harness deployment 
* Added ` "ec2:AssignPrivateIpAddresses", "ec2:UnassignPrivateIpAddresses"` to default execution policy
to bring it inline with Amazon's default AWSLambdaVPCAccessExecutionRole.
* Added an optional `lambda_description` variable
* Added descriptions to variables for improved IDE code hints
