### PR TITLE
update default value for lambda runtime

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "lambda_zip_path" {
 variable "lambda_runtime" {
   description = "The runtime to use for the lambda function"
   type        = string
-  default     = "nodejs10.x"
+  default     = "nodejs14.x"
 }
 
 variable "lambda_timeout" {


### PR DESCRIPTION
The default value is pointing to a deprecated version of the runtime in aws lambda, I suggest updateing it to v14 which is the laltest supported