### PR TITLE
Updates default node version to 14, as node 10 is no longer supported for new lambdas.

### DIFF
--- a/spec/lambda_spec.rb
+++ b/spec/lambda_spec.rb
@@ -11,7 +11,7 @@ describe 'lambda' do
 
     it { should have_env_vars(["TEST_ENV_VARIABLE"]) }
 
-    its(:runtime) { should eq "nodejs10.x" }
+    its(:runtime) { should eq "nodejs14.x" }
     its(:memory_size) { should eq 128 }
     its(:timeout) { should eq 30 }
     its(:handler) { should eq handler }

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "lambda_zip_path" {
 variable "lambda_runtime" {
   description = "The runtime to use for the lambda function"
   type        = string
-  default     = "nodejs10.x"
+  default     = "nodejs14.x"
 }
 
 variable "lambda_timeout" {


### PR DESCRIPTION
Hello, 

On creating a lambda through this module by default, currently you'll get the message:

`"The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions."`

This isn't too bad because you can specify the runtime as a variable, but thought it would be better if the default was a runtime that works.

I had some issues running the tests for this as they're integration based, so not sure if there's additional setup I've missed or if this would require me to use my own AWS environment to test. Please let me know if there's anything more I can do to verify these changes.

Thanks,
Jordan